### PR TITLE
Add .dependency_licenses directory override support

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ octothorp followed by a comment (which may not contain a comma!).
 
     commentable-char: Any character other than a ','
 
+You can also create a `.dependency_licenses` directory, and all files inside will be used as overrides, with their paths applied to the parent directory.
+
 Docker Image
 ------------
 

--- a/override.go
+++ b/override.go
@@ -31,14 +31,20 @@ func loadOverrides() {
 		if filepath.Base(name) == `.git` {
 			return filepath.SkipDir
 		}
-
+		if info.IsDir() {
+			return nil
+		}
 		if strings.HasSuffix(name, `.dependency_license`) {
-			loadOverrideFile(name)
+			loadOverrideFile(name, false)
+		}
+		if strings.Contains(name, `.dependency_licenses`+string(os.PathSeparator)) {
+			loadOverrideFile(name, true)
 		}
 		return nil
 	})
 }
-func loadOverrideFile(overrideFile string) {
+
+func loadOverrideFile(overrideFile string, isDir bool) {
 	if _, err := os.Stat(overrideFile); err != nil {
 		return
 	}
@@ -50,6 +56,9 @@ func loadOverrideFile(overrideFile string) {
 	defer f.Close()
 
 	prefix := filepath.Dir(overrideFile)
+	if isDir {
+		prefix = filepath.Dir(prefix) // for files in .dependency_files directories, apply the regexes to the parent directory
+	}
 	if prefix == `.` {
 		prefix = ``
 	} else {


### PR DESCRIPTION
Adds .dependency_licenses override support.

This is especially useful for projects which graft files via git cherry-pick, and therefore want to create standalone files which can be merged with no risk of conflict.

This allows those projects to create a .dependency_licenses/file to match their graft file, and not get conflicts on that either.