### PR TITLE
Add license to build-docker-images

### DIFF
--- a/build-docker-images
+++ b/build-docker-images
@@ -1,4 +1,21 @@
 #!/usr/bin/env bash
+
+# Copyright 2019 Comcast Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set -x
 
 pushd "${0%/*}"


### PR DESCRIPTION
Fixes a weasel error when weasel is run against this repo:

```weasel
Error                    Unknown-Bourne-Again! build-docker-images
```