### PR TITLE
Replace go get with go install

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ This is an automatic license checker aimed at ensuring compliance with
 the Apache Software Foundation processes. It does not ensure compliance,
 but it catches many common errors automatically.
 
-To get started quickly, install `weasel` with `go get`:
+To get started quickly, install `weasel` with `go install`:
 
-    go get github.com/comcast/weasel
+    go install github.com/comcast/weasel
 
 Then, `cd` into your project's directory and run:
 

--- a/vendor/github.com/google/licenseclassifier/.travis.yml
+++ b/vendor/github.com/google/licenseclassifier/.travis.yml
@@ -9,7 +9,7 @@ matrix:
     - go: master
   fast_finish: true
 script:
-  - go install -t -v ./...
+  - go get -t -v ./...
   - diff -u <(echo -n) <(gofmt -d -s .)
   - go generate -x ./... && git diff --exit-code; code=$?; git checkout -- .; (exit $code) # Check that go generate ./... produces a zero diff; clean up any changes afterwards.
   - go vet .

--- a/vendor/github.com/google/licenseclassifier/.travis.yml
+++ b/vendor/github.com/google/licenseclassifier/.travis.yml
@@ -9,7 +9,7 @@ matrix:
     - go: master
   fast_finish: true
 script:
-  - go get -t -v ./...
+  - go install -t -v ./...
   - diff -u <(echo -n) <(gofmt -d -s .)
   - go generate -x ./... && git diff --exit-code; code=$?; git checkout -- .; (exit $code) # Check that go generate ./... produces a zero diff; clean up any changes afterwards.
   - go vet .


### PR DESCRIPTION
go get is no longer recommended for installing libraries in Go 1.17+ and should be replaced with go install.